### PR TITLE
fix for compilation problem under Debian

### DIFF
--- a/src/guile.h
+++ b/src/guile.h
@@ -21,7 +21,7 @@
 #ifndef GUILE_H
 #define GUILE_H
 
-#include <libguile/tags.h>
+#include <libguile/__scm.h>
 
 void initGuileInterface();
 SCM smobAnimated_make(class Animated* a);


### PR DESCRIPTION
Change of first guile include file, tags.h causes incorrect order due to include-guards