### PR TITLE
Increase the overall geometry detail

### DIFF
--- a/src/ball.cc
+++ b/src/ball.cc
@@ -113,14 +113,14 @@ void Ball::generateBuffers(const GLuint *idxbufs, const GLuint *databufs,
     int detail;
     switch (ballResolution) {
     case BALL_HIRES:
-      detail = 8;
+      detail = 20;
       break;
     default:
     case BALL_NORMAL:
-      detail = 6;
+      detail = 14;
       break;
     case BALL_LORES:
-      detail = 3;
+      detail = 8;
       break;
     }
     countObjectSpherePoints(&ntries, &nverts, detail);
@@ -427,14 +427,14 @@ void Ball::drawBuffers1(const GLuint *vaolist) const {
     int detail;
     switch (ballResolution) {
     case BALL_HIRES:
-      detail = 8;
+      detail = 20;
       break;
     default:
     case BALL_NORMAL:
-      detail = 6;
+      detail = 14;
       break;
     case BALL_LORES:
-      detail = 3;
+      detail = 8;
       break;
     }
     countObjectSpherePoints(&ntries, &nverts, detail);

--- a/src/goal.cc
+++ b/src/goal.cc
@@ -44,7 +44,7 @@ void Goal::generateBuffers(const GLuint *idxbufs, const GLuint *databufs,
                            const GLuint *vaolist, bool mustUpdate) const {
   if (!mustUpdate || !visible) return;
 
-  const int nfacets = 11;
+  const int nfacets = 22;
   GLfloat inner_arc[2 + nfacets][2];
   GLfloat outer_arc[2 + nfacets][2];
   GLfloat normals[2 + nfacets][2];
@@ -135,7 +135,7 @@ void Goal::generateBuffers(const GLuint *idxbufs, const GLuint *databufs,
 void Goal::drawBuffers1(const GLuint *vaolist) const {
   if (!visible) return;
 
-  const int nfacets = 11;
+  const int nfacets = 22;
 
   glEnable(GL_CULL_FACE);
   glDisable(GL_BLEND);

--- a/src/pipe.cc
+++ b/src/pipe.cc
@@ -49,7 +49,7 @@ void Pipe::generateBuffers(const GLuint *idxbufs, const GLuint *databufs,
   up = crossProduct(dir, right);
   if (up[2] < 0.0) up = -up;
 
-  const int nfacets = 24;
+  const int nfacets = 32;
 
   // Draw pipe
   GLfloat data[2 * nfacets][8];
@@ -108,7 +108,7 @@ void Pipe::drawTrunk(const GLuint *vaolist) const {
   setObjectUniforms(specularColor, 1., Lighting_Regular);
   glBindTexture(GL_TEXTURE_2D, textureBlank);
 
-  int nfacets = 24;
+  int nfacets = 32;
 
   glBindVertexArray(vaolist[0]);
   glDrawElements(GL_TRIANGLES, 3 * 2 * nfacets, GL_UNSIGNED_SHORT, (void *)0);

--- a/src/setupMode.cc
+++ b/src/setupMode.cc
@@ -144,7 +144,7 @@ void SetupMode::display() {
   // Create sphere
   int ntries = 0;
   int nverts = 0;
-  int detail = 7;
+  int detail = 20;
   countObjectSpherePoints(&ntries, &nverts, detail);
   GLfloat *data = new GLfloat[nverts * 8];
   ushort *idxs = new ushort[ntries * 3];

--- a/src/switch.cc
+++ b/src/switch.cc
@@ -48,7 +48,7 @@ void CSwitch::releaseCallbacks() {
 
 void CSwitch::generateBuffers(const GLuint *idxbufs, const GLuint *databufs,
                               const GLuint *vaolist, bool mustUpdate) const {
-  const int nfacets = 6;
+  const int nfacets = 16;
   GLfloat lever_length = 0.3f;
   GLfloat lever_end = 0.03f;
   GLfloat body_wid = 0.15f;
@@ -149,7 +149,7 @@ void CSwitch::drawBuffers1(const GLuint *vaolist) const {
   glDisable(GL_BLEND);
   glEnable(GL_CULL_FACE);
 
-  const int nfacets = 6;
+  const int nfacets = 16;
   setActiveProgramAndUniforms(Shader_Object);
   setObjectUniforms(specularColor, 0.12, Lighting_Regular);
   glBindTexture(GL_TEXTURE_2D, textureBlank);


### PR DESCRIPTION
This makes balls and other rounded geometry look better on high-resolution displays. To my knowledge, the current detail levels were never touched past 2006-2007. This change should still run plenty fast even on low-end graphics cards released several years ago :slightly_smiling_face: 	

PS: Are the various ball detail levels still in use? No matter which graphics level I set, the in-game ball always seems to use the highest detail level. This might be just me though, maybe I overlooked something during testing.

## Preview

### Before

![2019-06-13_20 06 37](https://user-images.githubusercontent.com/180032/59462097-35419200-8e23-11e9-8383-9e6d413cc217.png)

### After

![2019-06-13_20 13 51](https://user-images.githubusercontent.com/180032/59462091-3246a180-8e23-11e9-859a-60cfbb6dc7c5.png)
