### PR TITLE
Add developer name to AppStream metadata file

### DIFF
--- a/share/freedesktop/trackballs.appdata.xml
+++ b/share/freedesktop/trackballs.appdata.xml
@@ -4,6 +4,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Trackballs</name>
+  <developer id="io.github.trackballs">
+    <name>The Trackballs Project</name>
+  </developer>
   <summary>Steer a marble ball through a labyrinth</summary>
   <description>
     <p>


### PR DESCRIPTION
This is a requirement at https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-developer-name