### PR TITLE
Add desktop launchable to to AppStream metadata file

### DIFF
--- a/share/freedesktop/trackballs.appdata.xml
+++ b/share/freedesktop/trackballs.appdata.xml
@@ -48,4 +48,5 @@
     <release version="1.2.1" date="2017-06-16" />
     <release version="1.2.0" date="2017-06-04" />
   </releases>
+  <launchable type="desktop-id">trackballs.desktop</launchable>
 </component>


### PR DESCRIPTION
Another new requirement: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#launchable